### PR TITLE
TA13084 escape slashes in swagger parameters

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -992,10 +992,14 @@
     for (var i = 0; i < params.length; i++) {
       var param = params[i];
       if (param.paramType === 'path') {
-        if (typeof args[param.name] !== 'undefined') {
+        var val = args[param.name];
+        if (typeof val !== 'undefined') {
           // apply path params and remove from args
           var reg = new RegExp('\\{\\s*?' + param.name + '.*?\\}(?=\\s*?(\\/?|$))', 'gi');
-          url = url.replace(reg, this.encodePathParam(args[param.name]));
+          if (!param.unencoded) {
+              val = this.encodePathParam(val);
+          }
+          url = url.replace(reg, val);
           delete args[param.name];
         }
         else


### PR DESCRIPTION
add "unencoded" attr to each parameter to decide if a parameter should be url encoded or not. Normally it should be always encoded, however to support proxy URLs in swagger we need to make exception in that case.
