### PR TITLE
NEX-14013 No API version support for /api-docs in latest 5.1.0 develo…

### DIFF
--- a/dist/lib/swagger-client.js
+++ b/dist/lib/swagger-client.js
@@ -332,7 +332,8 @@ SwaggerClient.prototype.build = function() {
     url: this.url,
     method: "get",
     headers: {
-      accept: "application/json, */*"
+      accept: "application/json, */*",
+      "accept-version": "*"
     },
     on: {
       error: function(response) {
@@ -863,6 +864,8 @@ Operation.prototype.execute = function(arg1, arg2, arg3, arg4, parent) {
         args.body = args[param.name];
     }
   }
+  // TODO: implement support for multiple versions
+  headers['Accept-Version'] = "*";
   // handle form params
   if(headers['Content-Type'] === 'application/x-www-form-urlencoded') {
     var encoded = "";

--- a/dist/lib/swagger.js
+++ b/dist/lib/swagger.js
@@ -163,7 +163,8 @@
       url: this.url,
       method: 'GET',
       headers: {
-        accept: _this.swaggerRequstHeaders
+        accept: _this.swaggerRequstHeaders,
+        'accept-version': '*'
       },
       on: {
         error: function (response) {
@@ -399,7 +400,8 @@
         method: 'GET',
         useJQuery: this.useJQuery,
         headers: {
-          accept: this.swaggerRequstHeaders
+          accept: this.swaggerRequstHeaders,
+          'accept-version': '*'
         },
         on: {
           response: function (resp) {

--- a/lib/swagger-client.js
+++ b/lib/swagger-client.js
@@ -332,7 +332,8 @@ SwaggerClient.prototype.build = function() {
     url: this.url,
     method: "get",
     headers: {
-      accept: "application/json, */*"
+      accept: "application/json, */*",
+      "accept-version": "*"
     },
     on: {
       error: function(response) {
@@ -863,6 +864,8 @@ Operation.prototype.execute = function(arg1, arg2, arg3, arg4, parent) {
         args.body = args[param.name];
     }
   }
+  // TODO: implement support for multiple versions
+  headers['Accept-Version'] = "*";
   // handle form params
   if(headers['Content-Type'] === 'application/x-www-form-urlencoded') {
     var encoded = "";

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -163,7 +163,8 @@
       url: this.url,
       method: 'GET',
       headers: {
-        accept: _this.swaggerRequstHeaders
+        accept: _this.swaggerRequstHeaders,
+        'accept-version': '*'
       },
       on: {
         error: function (response) {
@@ -399,7 +400,8 @@
         method: 'GET',
         useJQuery: this.useJQuery,
         headers: {
-          accept: this.swaggerRequstHeaders
+          accept: this.swaggerRequstHeaders,
+          'accept-version': '*'
         },
         on: {
           response: function (resp) {


### PR DESCRIPTION
…per code

Always use '*' in REST API requests (which means "use the latest version")